### PR TITLE
Add Depends to "hard" dependencies

### DIFF
--- a/R/plot_dependency_graph.R
+++ b/R/plot_dependency_graph.R
@@ -17,7 +17,7 @@ plot_dependency_graph <- function(pkg = ".", suggests = FALSE, option = "cividis
 
   pkg <- devtools::as.package(pkg)
 
-  dependencies <- unlist(strsplit(pkg$imports, split = "\n"))
+  dependencies <- unlist(strsplit(c(pkg$depends, pkg$imports), split = "\n"))
   dependencies <- gsub("\\n| \\(.+\\)|,", "", dependencies)
   dependency_graph <- miniCRAN::makeDepGraph(
     pkg = dependencies


### PR DESCRIPTION
Hi @crsh, while looking at the dependency grapg of papaja, I figured that tinylabels was not included in the dependency graph. I think this is because depends are not taken care of, here.